### PR TITLE
Fixed error occurring when too many buttons are present

### DIFF
--- a/Eevee.Sleep.Bot/Enums/ButtonId.cs
+++ b/Eevee.Sleep.Bot/Enums/ButtonId.cs
@@ -4,4 +4,6 @@ public enum ButtonId {
     RoleChanger,
     RoleAdder,
     RoleRemover,
+    PageNext,
+    PagePrevious,
 }

--- a/Eevee.Sleep.Bot/Models/Pagination/DiscordPaginationContext.cs
+++ b/Eevee.Sleep.Bot/Models/Pagination/DiscordPaginationContext.cs
@@ -1,46 +1,57 @@
-namespace Eevee.Sleep.Bot.Models.Pagination;
-
 using Eevee.Sleep.Bot.Utils;
 using Microsoft.Extensions.Caching.Memory;
 
+namespace Eevee.Sleep.Bot.Models.Pagination;
+
 public static class DiscordPaginationContext<T> where T : class {
-    private static readonly MemoryCache _cache = new(new MemoryCacheOptions());
+    // ReSharper disable once StaticMemberInGenericType
+    private static readonly MemoryCache Cache = new(new MemoryCacheOptions());
 
     public static void SaveState(string key, PaginationState<T> state, TimeSpan ttl) {
-        _cache.Set(key, state, new MemoryCacheEntryOptions {
-            AbsoluteExpirationRelativeToNow = ttl
-        });
+        Cache.Set(
+            key,
+            state,
+            new MemoryCacheEntryOptions { AbsoluteExpirationRelativeToNow = ttl }
+        );
     }
 
     public static PaginationState<T>? GetState(string key) {
-        return _cache.TryGetValue(key, out var state) ? state as PaginationState<T> : null;
+        return Cache.TryGetValue(key, out var state) ? state as PaginationState<T> : null;
     }
 
     public static void RemoveState(string key) {
-        _cache.Remove(key);
+        Cache.Remove(key);
     }
 
     public static void GotoNextPage(string key) {
         var state = GetState(key);
-        if (state != null) {
-            if (state.CurrentPage < state.TotalPages) {
-                state.CurrentPage++;
-                SaveState(key, state, TimeSpan.FromSeconds(GlobalConst.DiscordPaginationParams.ttl));
-            }
+        if (state == null) {
+            return;
         }
+
+        if (state.CurrentPage >= state.TotalPages) {
+            return;
+        }
+
+        state.CurrentPage++;
+        SaveState(key, state, TimeSpan.FromSeconds(GlobalConst.DiscordPaginationParams.Ttl));
     }
 
     public static void GotoPreviousPage(string key) {
         var state = GetState(key);
-        if (state != null) {
-            if (state.CurrentPage > 1) {
-                state.CurrentPage--;
-                SaveState(key, state, TimeSpan.FromSeconds(GlobalConst.DiscordPaginationParams.ttl));
-            }
+        if (state == null) {
+            return;
         }
+
+        if (state.CurrentPage <= 1) {
+            return;
+        }
+
+        state.CurrentPage--;
+        SaveState(key, state, TimeSpan.FromSeconds(GlobalConst.DiscordPaginationParams.Ttl));
     }
 
     public static void CleanupExpiredStates() {
-        _cache.Compact(0);
+        Cache.Compact(0);
     }
 }

--- a/Eevee.Sleep.Bot/Models/Pagination/DiscordPaginationContext.cs
+++ b/Eevee.Sleep.Bot/Models/Pagination/DiscordPaginationContext.cs
@@ -1,0 +1,46 @@
+namespace Eevee.Sleep.Bot.Models.Pagination;
+
+using Eevee.Sleep.Bot.Utils;
+using Microsoft.Extensions.Caching.Memory;
+
+public static class DiscordPaginationContext<T> where T : class {
+    private static readonly MemoryCache _cache = new(new MemoryCacheOptions());
+
+    public static void SaveState(string key, PaginationState<T> state, TimeSpan ttl) {
+        _cache.Set(key, state, new MemoryCacheEntryOptions {
+            AbsoluteExpirationRelativeToNow = ttl
+        });
+    }
+
+    public static PaginationState<T>? GetState(string key) {
+        return _cache.TryGetValue(key, out var state) ? state as PaginationState<T> : null;
+    }
+
+    public static void RemoveState(string key) {
+        _cache.Remove(key);
+    }
+
+    public static void GotoNextPage(string key) {
+        var state = GetState(key);
+        if (state != null) {
+            if (state.CurrentPage < state.TotalPages) {
+                state.CurrentPage++;
+                SaveState(key, state, TimeSpan.FromSeconds(GlobalConst.DiscordPaginationParams.ttl));
+            }
+        }
+    }
+
+    public static void GotoPreviousPage(string key) {
+        var state = GetState(key);
+        if (state != null) {
+            if (state.CurrentPage > 1) {
+                state.CurrentPage--;
+                SaveState(key, state, TimeSpan.FromSeconds(GlobalConst.DiscordPaginationParams.ttl));
+            }
+        }
+    }
+
+    public static void CleanupExpiredStates() {
+        _cache.Compact(0);
+    }
+}

--- a/Eevee.Sleep.Bot/Models/Pagination/PaginationState.cs
+++ b/Eevee.Sleep.Bot/Models/Pagination/PaginationState.cs
@@ -1,0 +1,11 @@
+using Eevee.Sleep.Bot.Enums;
+
+namespace Eevee.Sleep.Bot.Models.Pagination;
+
+public class PaginationState<T> where T : class {
+    public required int CurrentPage { get; set; }
+    public required int TotalPages { get; set; }
+    public required IEnumerable<T> Collection { get; set; }
+    public required ButtonId ActionButtonId { get; set; }
+    public DateTime LastUpdated { get; set; } = DateTime.UtcNow;
+}

--- a/Eevee.Sleep.Bot/Models/Pagination/PaginationState.cs
+++ b/Eevee.Sleep.Bot/Models/Pagination/PaginationState.cs
@@ -4,8 +4,12 @@ namespace Eevee.Sleep.Bot.Models.Pagination;
 
 public class PaginationState<T> where T : class {
     public required int CurrentPage { get; set; }
-    public required int TotalPages { get; set; }
-    public required IEnumerable<T> Collection { get; set; }
-    public required ButtonId ActionButtonId { get; set; }
+
+    public required int TotalPages { get; init; }
+
+    public required IEnumerable<T> Collection { get; init; }
+
+    public required ButtonId ActionButtonId { get; init; }
+
     public DateTime LastUpdated { get; set; } = DateTime.UtcNow;
 }

--- a/Eevee.Sleep.Bot/Modules/SlashCommands/RoleManagementSlashModule.cs
+++ b/Eevee.Sleep.Bot/Modules/SlashCommands/RoleManagementSlashModule.cs
@@ -3,6 +3,9 @@ using Discord.Interactions;
 using Eevee.Sleep.Bot.Controllers.Mongo;
 using Eevee.Sleep.Bot.Enums;
 using Eevee.Sleep.Bot.Extensions;
+using Eevee.Sleep.Bot.Models;
+using Eevee.Sleep.Bot.Models.Pagination;
+using Eevee.Sleep.Bot.Utils;
 using Eevee.Sleep.Bot.Utils.DiscordMessageMaker;
 using JetBrains.Annotations;
 
@@ -45,6 +48,17 @@ public class RoleManagementSlashModule : InteractionModuleBase<SocketInteraction
             return SendEphemeralMessageToBeDeletedAsync("No roles available for selection.");
         }
 
+        DiscordPaginationContext<TrackedRoleModel>.SaveState(
+            Context.User.Id.ToString(),
+            new PaginationState<TrackedRoleModel> {
+                CurrentPage = 1,
+                TotalPages = (int)Math.Ceiling((double)roles.Length / GlobalConst.DiscordPaginationParams.ItemsPerPage),
+                Collection = roles,
+                ActionButtonId = ButtonId.RoleChanger
+            },
+            ttl: TimeSpan.FromSeconds(GlobalConst.DiscordPaginationParams.ttl)
+        );
+
         string[] messages = [
             "Select the role to display.",
             "",
@@ -80,6 +94,17 @@ public class RoleManagementSlashModule : InteractionModuleBase<SocketInteraction
             return SendEphemeralMessageToBeDeletedAsync("No roles available for addition.");
         }
 
+        DiscordPaginationContext<TrackedRoleModel>.SaveState(
+            Context.User.Id.ToString(),
+            new PaginationState<TrackedRoleModel> {
+                CurrentPage = 1,
+                TotalPages = (int)Math.Ceiling((double)roles.Length / GlobalConst.DiscordPaginationParams.ItemsPerPage),
+                Collection = roles,
+                ActionButtonId = ButtonId.RoleAdder
+            },
+            ttl: TimeSpan.FromSeconds(GlobalConst.DiscordPaginationParams.ttl)
+        );
+
         string[] messages = [
             "Select a role to obtain the ownership on Discord.",
             "This does not guarantee that the selected role will show. To ensure the selected role shows up, use `/role display` instead.",
@@ -108,6 +133,17 @@ public class RoleManagementSlashModule : InteractionModuleBase<SocketInteraction
         if (roles.Length == 0) {
             return SendEphemeralMessageToBeDeletedAsync("No roles available for removal.");
         }
+
+        DiscordPaginationContext<TrackedRoleModel>.SaveState(
+            Context.User.Id.ToString(),
+            new PaginationState<TrackedRoleModel> {
+                CurrentPage = 1,
+                TotalPages = (int)Math.Ceiling((double)roles.Length / GlobalConst.DiscordPaginationParams.ItemsPerPage),
+                Collection = roles,
+                ActionButtonId = ButtonId.RoleRemover
+            },
+            ttl: TimeSpan.FromSeconds(GlobalConst.DiscordPaginationParams.ttl)
+        );
 
         string[] messages = [
             "Select a role to remove the ownership on Discord.",
@@ -145,14 +181,14 @@ public class RoleManagementSlashModule : InteractionModuleBase<SocketInteraction
         }
 
         await response.ModifyAsync(x => {
-                x.Content = null;
-                x.Embed = DiscordMessageMakerForRoleChange.MakeChangeRoleResult(
-                    user,
-                    previousRoleIds,
-                    DiscordRoleRecordController.FindRoleIdsByUserId(user.Id),
-                    Colors.Success
-                );
-            }
+            x.Content = null;
+            x.Embed = DiscordMessageMakerForRoleChange.MakeChangeRoleResult(
+                user,
+                previousRoleIds,
+                DiscordRoleRecordController.FindRoleIdsByUserId(user.Id),
+                Colors.Success
+            );
+        }
         );
     }
 
@@ -176,14 +212,14 @@ public class RoleManagementSlashModule : InteractionModuleBase<SocketInteraction
         }
 
         await response.ModifyAsync(x => {
-                x.Content = null;
-                x.Embed = DiscordMessageMakerForRoleChange.MakeChangeRoleResult(
-                    user,
-                    previousRoleIds,
-                    DiscordRoleRecordController.FindRoleIdsByUserId(user.Id),
-                    Colors.Success
-                );
-            }
+            x.Content = null;
+            x.Embed = DiscordMessageMakerForRoleChange.MakeChangeRoleResult(
+                user,
+                previousRoleIds,
+                DiscordRoleRecordController.FindRoleIdsByUserId(user.Id),
+                Colors.Success
+            );
+        }
         );
     }
 

--- a/Eevee.Sleep.Bot/Modules/SlashCommands/RoleManagementSlashModule.cs
+++ b/Eevee.Sleep.Bot/Modules/SlashCommands/RoleManagementSlashModule.cs
@@ -52,11 +52,13 @@ public class RoleManagementSlashModule : InteractionModuleBase<SocketInteraction
             Context.User.Id.ToString(),
             new PaginationState<TrackedRoleModel> {
                 CurrentPage = 1,
-                TotalPages = (int)Math.Ceiling((double)roles.Length / GlobalConst.DiscordPaginationParams.ItemsPerPage),
+                TotalPages = (int)Math.Ceiling(
+                    (double)roles.Length / GlobalConst.DiscordPaginationParams.ItemsPerPage
+                ),
                 Collection = roles,
-                ActionButtonId = ButtonId.RoleChanger
+                ActionButtonId = ButtonId.RoleChanger,
             },
-            ttl: TimeSpan.FromSeconds(GlobalConst.DiscordPaginationParams.ttl)
+            ttl: TimeSpan.FromSeconds(GlobalConst.DiscordPaginationParams.Ttl)
         );
 
         string[] messages = [
@@ -98,11 +100,13 @@ public class RoleManagementSlashModule : InteractionModuleBase<SocketInteraction
             Context.User.Id.ToString(),
             new PaginationState<TrackedRoleModel> {
                 CurrentPage = 1,
-                TotalPages = (int)Math.Ceiling((double)roles.Length / GlobalConst.DiscordPaginationParams.ItemsPerPage),
+                TotalPages = (int)Math.Ceiling(
+                    (double)roles.Length / GlobalConst.DiscordPaginationParams.ItemsPerPage
+                ),
                 Collection = roles,
-                ActionButtonId = ButtonId.RoleAdder
+                ActionButtonId = ButtonId.RoleAdder,
             },
-            ttl: TimeSpan.FromSeconds(GlobalConst.DiscordPaginationParams.ttl)
+            ttl: TimeSpan.FromSeconds(GlobalConst.DiscordPaginationParams.Ttl)
         );
 
         string[] messages = [
@@ -138,11 +142,13 @@ public class RoleManagementSlashModule : InteractionModuleBase<SocketInteraction
             Context.User.Id.ToString(),
             new PaginationState<TrackedRoleModel> {
                 CurrentPage = 1,
-                TotalPages = (int)Math.Ceiling((double)roles.Length / GlobalConst.DiscordPaginationParams.ItemsPerPage),
+                TotalPages = (int)Math.Ceiling(
+                    (double)roles.Length / GlobalConst.DiscordPaginationParams.ItemsPerPage
+                ),
                 Collection = roles,
-                ActionButtonId = ButtonId.RoleRemover
+                ActionButtonId = ButtonId.RoleRemover,
             },
-            ttl: TimeSpan.FromSeconds(GlobalConst.DiscordPaginationParams.ttl)
+            ttl: TimeSpan.FromSeconds(GlobalConst.DiscordPaginationParams.Ttl)
         );
 
         string[] messages = [
@@ -188,8 +194,7 @@ public class RoleManagementSlashModule : InteractionModuleBase<SocketInteraction
                 DiscordRoleRecordController.FindRoleIdsByUserId(user.Id),
                 Colors.Success
             );
-        }
-        );
+        });
     }
 
     [SlashCommand("remove-all", "Remove all tracked roles.")]
@@ -219,8 +224,7 @@ public class RoleManagementSlashModule : InteractionModuleBase<SocketInteraction
                 DiscordRoleRecordController.FindRoleIdsByUserId(user.Id),
                 Colors.Success
             );
-        }
-        );
+        });
     }
 
     [SlashCommand("show", "Shows all the owned tracked roles.")]

--- a/Eevee.Sleep.Bot/Program.cs
+++ b/Eevee.Sleep.Bot/Program.cs
@@ -12,6 +12,7 @@ using Eevee.Sleep.Bot.Workers.ActivationChecker;
 using Eevee.Sleep.Bot.Workers.ActivationChecker.Removal;
 using Eevee.Sleep.Bot.Workers.Announcement;
 using Eevee.Sleep.Bot.Workers.Crawlers;
+using Eevee.Sleep.Bot.Workers.PaginationContext;
 
 var socketConfig = new DiscordSocketConfig {
     GatewayIntents =
@@ -62,6 +63,7 @@ builder.Services
     .AddHostedService<ActivationCheckerWorker>()
     .AddHostedService<ActivationKeyRemovalWatcher>()
     .AddHostedService<ActivationDataRemovalWatcher>()
+    .AddHostedService<DiscordPaginationContextCleanupWorker>()
     .AddControllers();
 
 var app = builder

--- a/Eevee.Sleep.Bot/Utils/GlobalConst.cs
+++ b/Eevee.Sleep.Bot/Utils/GlobalConst.cs
@@ -12,4 +12,10 @@ public static class GlobalConst {
 
         public const string Afdian = "afdian";
     }
+
+    public static class DiscordPaginationParams {
+        public const int ttl = 3 * 60; // 3 minutes
+        public const int ItemsPerPage = 4;
+
+    }
 }

--- a/Eevee.Sleep.Bot/Utils/GlobalConst.cs
+++ b/Eevee.Sleep.Bot/Utils/GlobalConst.cs
@@ -14,8 +14,8 @@ public static class GlobalConst {
     }
 
     public static class DiscordPaginationParams {
-        public const int ttl = 3 * 60; // 3 minutes
-        public const int ItemsPerPage = 4;
+        public const int Ttl = 3 * 60; // 3 minutes
 
+        public const int ItemsPerPage = 4;
     }
 }

--- a/Eevee.Sleep.Bot/Workers/PaginationContext/DiscordPaginationContextCleanupWorker.cs
+++ b/Eevee.Sleep.Bot/Workers/PaginationContext/DiscordPaginationContextCleanupWorker.cs
@@ -4,7 +4,7 @@ using Eevee.Sleep.Bot.Utils;
 namespace Eevee.Sleep.Bot.Workers.PaginationContext;
 
 public class DiscordPaginationContextCleanupWorker : BackgroundService {
-    private readonly TimeSpan _cleanupInterval = TimeSpan.FromSeconds(GlobalConst.DiscordPaginationParams.ttl / 2);
+    private readonly TimeSpan _cleanupInterval = TimeSpan.FromSeconds(GlobalConst.DiscordPaginationParams.Ttl / 2.0);
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken) {
         while (!stoppingToken.IsCancellationRequested) {

--- a/Eevee.Sleep.Bot/Workers/PaginationContext/DiscordPaginationContextCleanupWorker.cs
+++ b/Eevee.Sleep.Bot/Workers/PaginationContext/DiscordPaginationContextCleanupWorker.cs
@@ -1,0 +1,20 @@
+using Eevee.Sleep.Bot.Models.Pagination;
+using Eevee.Sleep.Bot.Utils;
+
+namespace Eevee.Sleep.Bot.Workers.PaginationContext;
+
+public class DiscordPaginationContextCleanupWorker : BackgroundService {
+    private readonly TimeSpan _cleanupInterval = TimeSpan.FromSeconds(GlobalConst.DiscordPaginationParams.ttl / 2);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken) {
+        while (!stoppingToken.IsCancellationRequested) {
+            DiscordPaginationContext<object>.CleanupExpiredStates();
+
+            try {
+                await Task.Delay(_cleanupInterval, stoppingToken);
+            } catch (TaskCanceledException) {
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Overview

- Fixed an issue where having too many buttons (26 or more) caused an error due to Discord's limitations.  
  - When there are more than 10 buttons, pagination is now applied to limit the number of buttons shown.
---
- Introduced a new context manager: `DiscordPaginationContext<T>` to manage button content.
  - Uses a memory cache with TTL to purge expired data.  
    - Since purging is not automatic, a new background worker was added to handle cleanup.
  - Managing everything through button custom IDs was not feasible, so we opted for using a context object.
  - A database felt like overkill for this purpose, so memory cache was chosen instead.
  - Peak memory usage remains comparable to that of normal command handling,  
    - because items are created per `userId` only.
---
- When a "Next Page" or "Previous Page" button is clicked, a new message is sent instead of editing the existing one.
  - Due to Discord's specifications, ephemeral messages cannot be edited or deleted afterward (since their message IDs cannot be retrieved).
  - Looked into alternatives but couldn’t find a clean workaround for this behavior.

## Example Screenshot
- For testing purposes, the number of items per page is limited to 3.
- In actual use, up to 10 roles will be displayed.

![image](https://github.com/user-attachments/assets/0c59465d-7274-4b30-abbc-30a615b8c606)
