### PR TITLE
Fix role list pagination to display 10 items per page and avoid 2000 character limit

### DIFF
--- a/Eevee.Sleep.Bot/Modules/SlashCommands/RoleManagementSlashModule.cs
+++ b/Eevee.Sleep.Bot/Modules/SlashCommands/RoleManagementSlashModule.cs
@@ -62,11 +62,7 @@ public class RoleManagementSlashModule : InteractionModuleBase<SocketInteraction
         );
 
         string[] messages = [
-            "Select the role to display.",
-            "",
-            "All tracked roles will be removed from after selecting the role to display.",
-            "Role ownership won't get affected by the removal, only the role assignment on Discord is affected.",
-            "",
+            ..DiscordMessageMakerForRoleChange.Messages.RoleDisplayHeader,
             ..DiscordMessageMakerForRoleChange.MakeRoleSelectCorrespondenceList(roles),
         ];
 
@@ -110,9 +106,7 @@ public class RoleManagementSlashModule : InteractionModuleBase<SocketInteraction
         );
 
         string[] messages = [
-            "Select a role to obtain the ownership on Discord.",
-            "This does not guarantee that the selected role will show. To ensure the selected role shows up, use `/role display` instead.",
-            "",
+            ..DiscordMessageMakerForRoleChange.Messages.RoleAddHeader,
             ..DiscordMessageMakerForRoleChange.MakeRoleSelectCorrespondenceList(roles),
         ];
 
@@ -152,9 +146,7 @@ public class RoleManagementSlashModule : InteractionModuleBase<SocketInteraction
         );
 
         string[] messages = [
-            "Select a role to remove the ownership on Discord.",
-            "This does not remove the actual ownership of the role. You can get them back using either `/role add` or `/role display` at any time.",
-            "",
+            ..DiscordMessageMakerForRoleChange.Messages.RoleRemoveHeader,
             ..DiscordMessageMakerForRoleChange.MakeRoleSelectCorrespondenceList(roles),
         ];
 

--- a/Eevee.Sleep.Bot/Utils/DiscordMessageMaker/DiscordMessageMakerForRoleChange.cs
+++ b/Eevee.Sleep.Bot/Utils/DiscordMessageMaker/DiscordMessageMakerForRoleChange.cs
@@ -6,10 +6,37 @@ using Eevee.Sleep.Bot.Models;
 namespace Eevee.Sleep.Bot.Utils.DiscordMessageMaker;
 
 public static class DiscordMessageMakerForRoleChange {
+    public static class Messages {
+        public static readonly string[] RoleDisplayHeader = [
+            "Select the role to display.",
+            "",
+            "All tracked roles will be removed from after selecting the role to display.",
+            "Role ownership won't get affected by the removal, only the role assignment on Discord is affected.",
+            "",
+        ];
+
+        public static readonly string[] RoleAddHeader = [
+            "Select a role to obtain the ownership on Discord.",
+            "This does not guarantee that the selected role will show. To ensure the selected role shows up, use `/role display` instead.",
+            "",
+        ];
+
+        public static readonly string[] RoleRemoveHeader = [
+            "Select a role to remove the ownership on Discord.",
+            "This does not remove the actual ownership of the role. You can get them back using either `/role add` or `/role display` at any time.",
+            "",
+        ];
+    }
+
     public static IEnumerable<string> MakeRoleSelectCorrespondenceList(
-        TrackedRoleModel[] roles
+        TrackedRoleModel[] roles,
+        int currentPage = 1,
+        int itemsPerPage = GlobalConst.DiscordPaginationParams.ItemsPerPage
     ) {
-        return roles.Select((role, idx) => $"`{idx + 1}` - {MentionUtils.MentionRole(role.RoleId)}");
+        var startIndex = (currentPage - 1) * itemsPerPage;
+        var pageRoles = roles.Skip(startIndex).Take(itemsPerPage).ToArray();
+        
+        return pageRoles.Select((role, idx) => $"`{startIndex + idx + 1}` - {MentionUtils.MentionRole(role.RoleId)}");
     }
 
     public static MessageComponent MakeRoleSelectButton(


### PR DESCRIPTION
closes #50

## about
The number of roles displayed is now set to 10 per button, to avoid character count limitations.
Behavior example:
This is debug data, so the roles are labeled "unknown-role," but please disregard.
| page1 | page2 |
| --- | --- |
|<img width="726" height="504" alt="image" src="https://github.com/user-attachments/assets/5f6d82d9-3f75-43ea-98fc-8941580a1921" /> |<img width="729" height="505" alt="image" src="https://github.com/user-attachments/assets/277bcad2-7e0d-4d23-9fe6-f42b4fe32c89" /> |


